### PR TITLE
Alg test page

### DIFF
--- a/AlgorithmAnalyzer/Backend/algorithms/algorithm_manager.py
+++ b/AlgorithmAnalyzer/Backend/algorithms/algorithm_manager.py
@@ -228,14 +228,14 @@ class AlgorithmManager:
         for user in users:
             for i, sample in enumerate(samples[user]):
                 pred, _ = self.models[user].predict(sample)
-                result.append([user, i, labels[user][i],  pred == labels[user][i]])
+                result.append([user, i, labels[user][i],  pred])
         return result
 
     def _test_multilabel_model(self, samples, labels, users, user_numbers):
         """
         This method is used by method `test` for multilabel algorithms.
         """
-        result = [[0] * (max(user_numbers) + 1) for _ in users]
+        result = [[0] * (max(user_numbers) + 2) for _ in users]
         for i, sample in enumerate(samples):
             if labels[i] not in user_numbers:
                 continue

--- a/AlgorithmAnalyzer/Backend/main.py
+++ b/AlgorithmAnalyzer/Backend/main.py
@@ -241,7 +241,12 @@ def test_algorithm(algorithm_name):
         sample_type='wav'
     )
 
-    return alg_manager.test(samples, labels, users, numbers), status.HTTP_200_OK
+    try:
+        result = alg_manager.test(samples, labels, users, numbers)
+    except NotTrainedException as e:
+        return str(e), 422
+
+    return result, status.HTTP_200_OK
 
 
 @app.route("/audio/<string:type>", methods=['POST'])

--- a/AlgorithmAnalyzer/Backend/sample_manager/SampleManager.py
+++ b/AlgorithmAnalyzer/Backend/sample_manager/SampleManager.py
@@ -659,6 +659,20 @@ class SampleManager:
             raise DatabaseException(e)
         return [usernames[num]['name'] for num in numbers]
 
+    def usernames_to_user_numbers(self, usernames: List[str]) -> List[int]:
+        """
+        Returns list of positions in the list of all users,
+        for users sorted by time created.
+        :param usernames: list of usernames to convert.
+        """
+        try:
+            all_usernames = self.db_collection.find({}, ['name']).sort('id', 1)
+        except errors.PyMongoError as e:
+            raise DatabaseException(e)
+
+        all_usernames = [username['name'] for username in all_usernames]
+        return [all_usernames.index(user) for user in usernames]
+
 
 class UsernameException(Exception):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Dodanie API do strony do testowania wszystkich algorytmów:

```
GET (POST?): /algorithms/test_all/<string:algorithm_name> {
        users: [lista usernamów, dla której zrobić testy]
}
```
Zwracane jest albo lista typu 
```
[[user_name, sample_number, fake, prediction]]
```
albo obiekt typu
```
{
        'users': [lista username'ów],
        'matrix': [[confussion matrix]]
}
```
Liczba wierszy to liczba użytkowników, a liczba kolumn to liczba wierszy + 1. Każdy wiersz mówi, do jakich klas trafiły próbki danego użytkownika; jeśli są w ostatniej kolumnie, to znaczy, że nie trafiły nigdzie.

To, co jest zwracane zależy od tego, czy algorytm jest multilabel czy nie.
```